### PR TITLE
test: cover case equivalent to test_singularity_conda in snakemake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           channels: conda-forge,nodefaults
 
+      - name: Setup Apptainer
+        if: runner.os == 'Linux'
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.5.3
+
       - name: Deploy external test env
         shell: bash -el {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,6 @@ build = { cmd = "python -m build", description = "Build the package into the dis
 check-build = { cmd = "python -m twine check dist/*", depends-on = [
   "build",
 ], description = "Check that the package can be uploaded" }
+
+[tool.pixi.feature.dev.target.linux-64.dependencies]
+apptainer = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,3 @@ build = { cmd = "python -m build", description = "Build the package into the dis
 check-build = { cmd = "python -m twine check dist/*", depends-on = [
   "build",
 ], description = "Check that the package can be uploaded" }
-
-[tool.pixi.feature.dev.target.linux-64.dependencies]
-apptainer = "*"

--- a/src/snakemake_software_deployment_plugin_conda/__init__.py
+++ b/src/snakemake_software_deployment_plugin_conda/__init__.py
@@ -42,7 +42,6 @@ from snakemake_software_deployment_plugin_conda.pinfiles import (
     get_match_specs_from_conda_pinfile,
 )
 
-
 __version__ = importlib.metadata.version("snakemake-software-deployment-plugin-conda")
 
 
@@ -395,9 +394,9 @@ class Env(PinnableEnvBase, CacheableEnvBase, DeployableEnvBase, EnvBase):
         return self._cache_assets.keys()
 
     async def cache_asset(self, asset: str, to_path: Path) -> None:
-        assert self._cache_assets is not None, (
-            "bug: get_cache_assets must be called before cache_asset"
-        )
+        assert (
+            self._cache_assets is not None
+        ), "bug: get_cache_assets must be called before cache_asset"
         record = self._cache_assets[asset]
 
         async with httpx.AsyncClient() as http_client:
@@ -423,6 +422,11 @@ class Env(PinnableEnvBase, CacheableEnvBase, DeployableEnvBase, EnvBase):
         # Unset within such that really only this env is instantiated within.
         # The hash will remain unchanged, as it is already computed and cached.
         self_copy.within = None
+        # Drop spec.within as well, it cannot be pickled and is not needed inside
+        #  of the "within" environment.
+        if self_copy.spec is not None:
+            self_copy.spec = copy.copy(self_copy.spec)
+            self_copy.spec.within = None
         # Unset _package_records_cache since it cannot be pickled.
         self_copy._package_records_cache = None
         self_copy._cache_assets = None

--- a/src/snakemake_software_deployment_plugin_conda/__init__.py
+++ b/src/snakemake_software_deployment_plugin_conda/__init__.py
@@ -394,9 +394,9 @@ class Env(PinnableEnvBase, CacheableEnvBase, DeployableEnvBase, EnvBase):
         return self._cache_assets.keys()
 
     async def cache_asset(self, asset: str, to_path: Path) -> None:
-        assert (
-            self._cache_assets is not None
-        ), "bug: get_cache_assets must be called before cache_asset"
+        assert self._cache_assets is not None, (
+            "bug: get_cache_assets must be called before cache_asset"
+        )
         record = self._cache_assets[asset]
 
         async with httpx.AsyncClient() as http_client:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,9 @@
 import os
+import shutil
 from pathlib import Path
 from typing import Optional, Type
+
+import pytest
 from snakemake_interface_software_deployment_plugins.tests import (
     TestSoftwareDeploymentBase,
     ShellExecutable,
@@ -20,6 +23,7 @@ from snakemake_software_deployment_plugin_conda import (
 from snakemake_software_deployment_plugin_container import Env as ContainerEnv
 from snakemake_software_deployment_plugin_container import EnvSpec as ContainerEnvSpec
 from snakemake_software_deployment_plugin_container import Settings as ContainerSettings
+from snakemake_software_deployment_plugin_container import Runtime
 
 
 # There can be multiple subclasses of SoftwareDeploymentProviderBase here.
@@ -112,6 +116,31 @@ class TestWithinContainer(Test):
 
     def get_within_settings(self) -> Optional[SoftwareDeploymentSettingsBase]:
         return ContainerSettings()
+
+
+@pytest.mark.skipif(
+    shutil.which("apptainer") is None, reason="apptainer is not available"
+)
+class TestWithinContainerApptainer(TestWithinContainer):
+    """Reproduces the apptainer squashfuse FUSE hang.
+
+    In contrast to the default udocker runtime, apptainer mounts SIF images (squashfs) via FUSE.
+    Importing rattler (dependency of snakemake_software_deployment_plugin_conda)
+      inside such a container (as done by `_run_method`, e.g. from `_platforms`)
+      intermittently deadlocks or panics when reading files from the image,
+    seems like there is a race in `squashfuse_ll`.
+
+    related to https://github.com/snakemake/snakemake/pull/3339#issuecomment-5216168878
+      and the test `test_singularity_conda`
+    """
+
+    __test__ = True
+
+    def get_within_spec(self):
+        return ContainerEnvSpec("condaforge/miniforge3:26.3.2-3")
+
+    def get_within_settings(self):
+        return ContainerSettings(runtime=Runtime.APPTAINER)
 
 
 class TestPypiWithinContainer(TestPypi):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -136,6 +136,15 @@ class TestWithinContainerApptainer(TestWithinContainer):
 
     __test__ = True
 
+    def _get_env(self, tmp_path):
+        # Reuse the base construction, then attach spec.within exactly like
+        # snakemake.deployment.SoftwareDeploymentManager.get_env does.
+        env = super()._get_env(tmp_path)
+        within_spec = self.get_within_spec()
+        assert within_spec is not None
+        env.spec.within = within_spec
+        return env
+
     def get_within_spec(self):
         return ContainerEnvSpec("condaforge/miniforge3:26.3.2-3")
 


### PR DESCRIPTION
Added a test to reproduce what happened in https://github.com/snakemake/snakemake/pull/3339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved execution of workloads configured to run inside Apptainer containers.

- **Tests**
  - Added coverage for Apptainer-based container execution.
  - Tests use an updated Miniforge environment and Apptainer runtime settings.
  - Tests automatically skip when Apptainer is unavailable.
  - Documented an intermittent startup hang related to SquashFS/FUSE behavior.
  - Continuous integration now provisions Apptainer on supported Linux environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->